### PR TITLE
Resource efficient GMAG variometer data retrieval script

### DIFF
--- a/src/thmsoc/arguments.py
+++ b/src/thmsoc/arguments.py
@@ -42,7 +42,7 @@ valid_gmag_usgs_variometer_station_vals = [
     'sfjd','spmn','sspa','s61a','t47a','u38b','wci' ,'whtx','wvt' ,'352a',
     'k62a','n51a','n53a','bouv','s39b','t57a','x48a','y49a','154a','456a',
     'midw']
-valid_gmag_usgs_variometer_station_args = valid_gmag_usgs_variometer_station_vals
+valid_gmag_usgs_variometer_station_args = valid_gmag_usgs_variometer_station_vals.copy()
 valid_gmag_usgs_variometer_station_args.append('all')
 
 def add_probe_arguments(p:argparse.ArgumentParser) -> None:
@@ -72,11 +72,16 @@ def expand_l2_arguments(args:argparse.Namespace) -> list[str]:
     else:
         return args.l2_types
 
+#class toLower(argparse.Action):
+#    def __call__(self, parser, namespace, values, option_string=None):
+#        lowercase_values = [v.lower() for v in values]
+#        setattr(namespace, self.dest, lowercase_values)
+
 def add_station_arguments(p:argparse.ArgumentParser) -> None:
-    p.add_argument("-c", "--station_codes", help="Stations to process, as THEMIS station code alias", nargs='*', choices=valid_gmag_usgs_variometer_station_args)
+    p.add_argument("-c", "--station_codes", help="Stations to process, as THEMIS station code alias", nargs='*', choices=valid_gmag_usgs_variometer_station_args, type=str.lower, default=['all'])
 
 def expand_station_arguments(args:argparse.Namespace) -> list[str]:
     if 'all' in args.station_codes:
-        return valid_gmag_usgs_variometer_station_args
+        return valid_gmag_usgs_variometer_station_vals
     else:
         return args.station_codes

--- a/src/thmsoc/cli/gmag_retrieve_usgs_variometer.py
+++ b/src/thmsoc/cli/gmag_retrieve_usgs_variometer.py
@@ -63,10 +63,5 @@ def main() -> int:
 
 if __name__ == "__main__":
     import sys
-    #sys.argv=["gmag_retrieve_usgs_variometer","-s","2025-11-17","-d","3","-c","anmo","s61a","-f","10","-r","2"]
-    #sys.argv=["gmag_retrieve_usgs_variometer","-s","2025-11-17","-d","3","-c","anmo","s61a","-f","1","-r","2"]
-    #sys.argv=["gmag_retrieve_usgs_variometer","-s","2026-03-03","-d","3","-c","bouv","-f","1","-r","2"]
     sys.argv=["gmag_retrieve_usgs_variometer","-s","2026-06-01","-d","1","-f","1","-r","2"]
-    #sys.argv=["gmag_retrieve_usgs_variometer","-s","2026-06-01","-d","1","-f","10","-r","2"]
-    #sys.argv=["gmag_retrieve_usgs_variometer","-s","2026-06-01","-d","1","-c","X48A","-f","10","-r","2"]
     raise SystemExit(main())

--- a/src/thmsoc/cli/gmag_retrieve_usgs_variometer.py
+++ b/src/thmsoc/cli/gmag_retrieve_usgs_variometer.py
@@ -3,7 +3,7 @@
 import argparse
 from thmsoc.gmag_retrieve_usgs_variometer import run_gmag_retrieve_usgs_variometer
 from thmsoc.arguments import add_trange_arguments, check_trange_arguments
-from thmsoc.arguments import add_station_arguments
+from thmsoc.arguments import add_station_arguments, expand_station_arguments
 
 def main() -> int:
     # Initialize argument parser
@@ -42,10 +42,14 @@ def main() -> int:
     # Check arguments
     check_trange_arguments(args)
 
+    # Expand station codes:
+    station_codes = expand_station_arguments(args)
+    
+
     exit_status = 0
     # Run the variometer retrieval script:
     exit_status = run_gmag_retrieve_usgs_variometer(
-        station_list=args.station_codes,
+        station_list=station_codes,
         start_date=args.start_date,
         end_date=args.end_date,
         days=args.days,
@@ -60,5 +64,9 @@ def main() -> int:
 if __name__ == "__main__":
     import sys
     #sys.argv=["gmag_retrieve_usgs_variometer","-s","2025-11-17","-d","3","-c","anmo","s61a","-f","10","-r","2"]
-    sys.argv=["gmag_retrieve_usgs_variometer","-s","2025-11-17","-d","3","-c","anmo","s61a","-f","1","-r","2"]
+    #sys.argv=["gmag_retrieve_usgs_variometer","-s","2025-11-17","-d","3","-c","anmo","s61a","-f","1","-r","2"]
+    #sys.argv=["gmag_retrieve_usgs_variometer","-s","2026-03-03","-d","3","-c","bouv","-f","1","-r","2"]
+    sys.argv=["gmag_retrieve_usgs_variometer","-s","2026-06-01","-d","1","-f","1","-r","2"]
+    #sys.argv=["gmag_retrieve_usgs_variometer","-s","2026-06-01","-d","1","-f","10","-r","2"]
+    #sys.argv=["gmag_retrieve_usgs_variometer","-s","2026-06-01","-d","1","-c","X48A","-f","10","-r","2"]
     raise SystemExit(main())

--- a/src/thmsoc/gmag_retrieve_usgs_variometer.py
+++ b/src/thmsoc/gmag_retrieve_usgs_variometer.py
@@ -260,7 +260,8 @@ def json2iaga2002(str_json_segment:str) -> str:
     if len(json_data[0]["values"]) == len(json_data[1]["values"]) == len(json_data[2]["values"]):
         data_length = len(json_data[0]["values"])
     else: 
-        raise ValueError("ERROR: Components have differing number of elements!","Component arrays had differing length")
+        data_length = max(len(json_data[0]["values"]),len(json_data[1]["values"]),len(json_data[2]["values"]))
+        #raise ValueError("ERROR: Components have differing number of elements!","Component arrays had differing length")
         
     # initialize with start time:
     # format: 2025-11-17T00:00:00.069Z
@@ -276,12 +277,13 @@ def json2iaga2002(str_json_segment:str) -> str:
         # DOY
         iaga_data_row_str += row_datetime.strftime('%j').ljust(8)
         # component 1:
-        if "NoneType" in [
-            type(json_data[0]["values"][i]).__name__,
-            type(json_data[1]["values"][i]).__name__,
-            type(json_data[2]["values"][i]).__name__]: raise ValueError("ERROR: JSON is missing data!","Segment was missing data.")
         for j in range(3):
-            iaga_data_row_str += ("%.2f" % json_data[j]["values"][i]).ljust(10)
+            try:
+                if type(json_data[j]["values"][i]).__name__ == "NoneType": 
+                    raise ValueError("ERROR: JSON is missing data!","Segment was missing data.")
+                iaga_data_row_str += ("%.2f" % json_data[j]["values"][i]).ljust(10)
+            except IndexError:
+                iaga_data_row_str += ("%.2f" % NINES).ljust(10)
         # component nul:
         iaga_data_row_str += ("%.2f" % NINES).ljust(7)
         
@@ -301,10 +303,11 @@ def decode2string(bytes_response):
     take in a urllib3 response object as bytes and decode to utf-8 function is separate from others so concurrent module can run decode calls in parallel
     '''
     try:
-        bytes_response_read = bytes_response.read()
+        #bytes_response_read = bytes_response.read()
         # we should be able to safely close the original url responses:
+        #bytes_response.close()
+        string_response=bytes_response.data.decode('utf-8') #bytes_response_read.decode('utf-8')
         bytes_response.close()
-        string_response=bytes_response_read.decode('utf-8')
         if string_response == '': 
             raise ValueError(
                 "ERROR! Decoded bytes_response is empty!",
@@ -367,7 +370,7 @@ def correct_start_time(
                 print("WARNING: Possible component array mismatch detected; modifying query to attempt correction.")
                 modified_start_time = correct_start_time(
                     station_code=station_code,
-                    start_datetime=start_datetime - dt.timedelta(milliseconds=1),
+                    start_datetime=start_datetime - dt.timedelta(milliseconds=99),
                     sampling_period=sampling_period,
                     recursive_run=True)
                 return modified_start_time
@@ -381,39 +384,81 @@ def retrieve_file_bytes(
         start_datetime:dt.datetime,
         end_datetime:dt.datetime,
         sampling_period:str,
-        max_num_retries:int):
-    # use parameters to construct query, make request:
-    if sampling_period == "0.1":
-        start_datetime = correct_start_time(
+        max_num_retries:int,
+        correct_time=True) -> urllib3.response.BaseHTTPResponse:
+    try:
+        # use parameters to construct query, make request:
+        #if sampling_period == "0.1" and correct_time:
+        #    corrected_time_start = dt.datetime.now()
+        #    start_datetime = correct_start_time(
+        #        station_code=station_code,
+        #        start_datetime=start_datetime,
+        #        sampling_period=sampling_period)
+        url=construct_usgs_query(
             station_code=station_code,
             start_datetime=start_datetime,
+            end_datetime=end_datetime,
             sampling_period=sampling_period)
-    url=construct_usgs_query(
-        station_code=station_code,
-        start_datetime=start_datetime,
-        end_datetime=end_datetime,
-        sampling_period=sampling_period)
-    # Attempt to make url request: 
-    http = urllib3.PoolManager(num_pools=24) # num_pools=10
-    retries_settings=urllib3.Retry(
-        connect=0,
-        read=max_num_retries,
-        backoff_factor=0.5)
-    url_response_bytes = http.request(
-        "GET", 
-        url, 
-        retries=retries_settings,
-        decode_content=False,
-        preload_content=False,
-        redirect=False,
-        timeout=30)
-    match url_response_bytes.status:
-        case 200:
-            return url_response_bytes
-        case _:
-            raise ValueError(
-                "ERROR: Invalid status returned: " + str(url_response_bytes.status) + ".",
-                "Bad response status code: " + str(url_response_bytes.status)) 
+        # Attempt to make url request: 
+        http = urllib3.PoolManager(num_pools=24) # num_pools=10
+        retries_settings=urllib3.Retry(
+            connect=0,
+            read=max_num_retries,
+            backoff_factor=0.5)
+        url_response_bytes = http.request(
+            "GET", 
+            url, 
+            retries=retries_settings,
+            decode_content=False,
+            preload_content=False,
+            redirect=False,
+            timeout=30)
+        match url_response_bytes.status:
+            case 200:
+                if b"HTTP/1.1 408 Request Timeout" in url_response_bytes.data:
+                    if max_num_retries > 0:
+                        print("Request timeout detected within response data. Attempting again")
+                        url_response_bytes_retry = retrieve_file_bytes(
+                            station_code=station_code,
+                            start_datetime=start_datetime,
+                            end_datetime=end_datetime,
+                            sampling_period=sampling_period,
+                            max_num_retries=max_num_retries-1,
+                            correct_time=False)
+                        return url_response_bytes_retry
+                    else:
+                        raise ValueError(
+                            "ERROR! Incomplete file due to timed out connection!",
+                            "Connection timed out during retrieval")
+                elif len(url_response_bytes.data) == 0:
+                    if max_num_retries > 0:
+                        print("Request returned empty; Attempting again...")
+                        url_response_bytes_retry = retrieve_file_bytes(
+                            station_code=station_code,
+                            start_datetime=start_datetime,
+                            end_datetime=end_datetime,
+                            sampling_period=sampling_period,
+                            max_num_retries=max_num_retries-1,
+                            correct_time=False)
+                        return url_response_bytes_retry
+                    else:
+                        raise ValueError(
+                            "ERROR! Decoded bytes_response is empty!",
+                            "Empty response")
+                else:
+                    return url_response_bytes
+            case _:
+                raise ValueError(
+                    "ERROR: Invalid status returned: " + str(url_response_bytes.status) + ".",
+                    "Bad response status code: " + str(url_response_bytes.status)) 
+    except urllib3.exceptions.TimeoutError:
+        raise ValueError(
+            "ERROR: Connection timed out!",
+            "Connection timed out during retrieval")
+    except urllib3.exceptions.MaxRetryError:
+        raise ValueError(
+            "ERROR: Connection could not be established after " + str(max_num_retries + 1) + " attempt(s)",
+            "Max connection retry limit reached")
 
 def retrieve_a_file(
         station_code:str,
@@ -435,38 +480,42 @@ def retrieve_a_file(
                     mirror_subdir = Path(f"{mirror_dir}/{station_code.lower()}/1_hz/{data_date.strftime('%Y')}/{data_date.strftime('%m')}")
                     mirror_subdir.mkdir(parents=True, exist_ok=True)
                     output_filepath_list.append(Path(f"{mirror_subdir}/{station_code.lower()}{data_date.strftime('%Y%m%d')}vsec.sec"))
-                duration=12 # duration of each segment, in hours # formerly 24
-                segment_end_str = "000"
+                duration=6 # duration of each segment, in hours # formerly 24
+                #segment_end_str = "000"
+                sampling_rate_td = dt.timedelta(seconds=1)
             case '10':
                 sampling_period_val='0.1'
                 workdir_subdir = Path(f"{variometer_workdir}/{sampling_rate}_hz")
                 Path(workdir_subdir).mkdir(parents=True, exist_ok=True)
                 output_filepath_list = [Path(f"{workdir_subdir}/{station_code.lower()}{data_date.strftime('%Y%m%d')}vdec.dec")]
-                duration=3 # duration of each segment, in hours # formerly 4
-                segment_end_str = "999"
+                duration=1 # duration of each segment, in hours # formerly 4
+                #segment_end_str = "000" # was 999
+                sampling_rate_td = dt.timedelta(milliseconds=100)
             case _:
                 raise ValueError("ERROR: Sampling rate not recognized","Invalid Sampling Rate")
+        
         print("Retrieving " + station_code.upper() + " data for "+ data_date.strftime('%Y-%m-%d') +" in " + str(round(24/duration)) + " segments... ")
         start_time_1file = dt.datetime.now()
         out_dict["LastAttemptedAccessTime"] = dt.datetime.strftime(start_time_1file,'%Y-%m-%d %H:%M:%S')
 
         # make requests to USGS server and collect response objects in a list: 
         url_response_bytes_list = []
-        # start hour increases by length of duration
+        date_start_dt = dt.datetime.strptime(data_date.strftime('%Y-%m-%d') + "T" + "00:00:00.000Z", '%Y-%m-%dT%H:%M:%S.%fZ')
         for start_hour in range(0, 24, duration):
             segment_start_time_1file = dt.datetime.now()
-            # end time will be 0.001 second before next segment start time:
-            end_hour = start_hour + duration - 1
-            data_date_str = data_date.strftime('%Y-%m-%d')
-            start_datetime_val=dt.datetime.strptime(data_date_str + "T" + str(start_hour) + ":00:00.000Z", '%Y-%m-%dT%H:%M:%S.%fZ')
-            end_datetime_val=dt.datetime.strptime(data_date_str + "T" + str(end_hour) + ":59:59."+segment_end_str+"Z", '%Y-%m-%dT%H:%M:%S.%fZ')
+            segment_name_str = str(round((start_hour+duration)/duration)) + "/"+str(round(24/duration))
+            #print("-> Retrieving segment "+ str(round((start_hour+duration)/duration)) + "/"+str(round(24/duration))+"...")
+            # start hour increases by length of duration
+            segment_start_dt = date_start_dt + dt.timedelta(hours = start_hour)
+            # end time is one segment duration after start time, but subtract sampling rate so times do not overlap:
+            segment_end_dt = segment_start_dt + dt.timedelta(hours = duration) - sampling_rate_td
             url_response_bytes = retrieve_file_bytes(
                 station_code=station_code,
-                start_datetime=start_datetime_val,
-                end_datetime=end_datetime_val,
+                start_datetime=segment_start_dt,
+                end_datetime=segment_end_dt,
                 sampling_period=sampling_period_val,
                 max_num_retries=max_num_retries)
-            print("-> Segment "+ str(round((start_hour+duration)/duration)) + "/"+str(round(24/duration))+" retrieval complete. Elapsed %.0f seconds." % (dt.datetime.now() - segment_start_time_1file).seconds)
+            print("-> Retrieval of segment "+ segment_name_str +" complete. Elapsed %.0f seconds." % (dt.datetime.now() - segment_start_time_1file).seconds)
             url_response_bytes_list.append(url_response_bytes)
         # Take list of byte responses and decode:
         decoding_start_time = dt.datetime.now()
@@ -497,21 +546,12 @@ def retrieve_a_file(
         end_time_1file = dt.datetime.now()
         print("File writing complete. Elapsed %.0f seconds." % (end_time_1file - writing_start_time).seconds)
         print("Total file retrieval complete. Elapsed time: %.0f seconds." % (end_time_1file - start_time_1file).seconds)
-    except urllib3.exceptions.TimeoutError:
-        raise ValueError(
-            "ERROR: Connection timed out!",
-            "Connection timed out during retrieval")
-    except urllib3.exceptions.MaxRetryError:
-        raise ValueError(
-            "ERROR: Connection could not be established after " + str(max_num_retries + 1) + " attempt(s)",
-            "Max connection retry limit reached")
-    
     except ValueError as error:
         print(error.args[0] + " File could not be written; Aborting file retrieval...")
         out_dict["error_status"] = error.args[1]
-    except:
-        print("ERROR! The output file could not be written.")
-        out_dict["error_status"] = "Failed to write data to output file."
+    #except:
+    #    print("ERROR! The output file could not be written.")
+    #    out_dict["error_status"] = "Failed to write data to output file."
     return out_dict
 
 def run_gmag_retrieve_usgs_variometer(

--- a/src/thmsoc/gmag_retrieve_usgs_variometer.py
+++ b/src/thmsoc/gmag_retrieve_usgs_variometer.py
@@ -1,87 +1,84 @@
 # src/thmsoc/gmag_retrieve_usgs_variometer.py
-import datetime as dt
-import urllib3
-from pathlib import Path
-import tomli
 import re
-from thmsoc import args_to_startend, batch_daterange
-from concurrent import futures
+import numpy
+import datetime as dt
+import json
+import tomli
+import urllib3
 import xml.etree.ElementTree as ET
+from pathlib import Path
+from concurrent import futures
+from thmsoc import args_to_startend, batch_daterange
 
-def list_max(in_list:list):
-    list_unique = list(dict.fromkeys(in_list))
-    list_unique.sort()
-    return list_unique[-1]
-
-# take in a urllib3 response object as bytes and decode to utf-8 function is separate from others so concurrent module can run decode calls in parallel
-def decode2string(bytes_response):
-    # TODO: create some kind of setting which can be updated to choose incomplete and protocol error responses. 
-    try:
-        bytes_response_read = bytes_response.read()
-        # we should be able to safely close the original url responses:
-        bytes_response.close()
-    except urllib3.exceptions.IncompleteRead:
-        # kluge since http.client.IncompleteRead has been thrown in process of handling exception:
-        try: 
-            return 'HTTP/1.1 408 Request Timeout'
-        except urllib3.exceptions.IncompleteRead:
-            #print("ERROR: Connection timed out! Aborting file retrieval...")
-            return 'HTTP/1.1 408 Request Timeout'
-    except urllib3.exceptions.ProtocolError:
-        #print("ERROR: Connection timed out! Aborting file retrieval...")
-        return 'HTTP/1.1 408 Request Timeout'
+def str_list_max(in_list:list[str]) -> str: 
+    if len(in_list) == 0:
+        return ""
     else:
-        string_response=bytes_response_read.decode('utf-8')
-        return string_response
+        return max(in_list)
 
 def construct_web_query(
         web_scheme='https',
         web_netloc='',
         web_path='',
-        query_list:list=[],
+        query_list:list=[tuple],
         query_separator='&',
         web_fragment=''
         ):
-    # construct_web_query assumes query_list is an iterable, where each element is a tuple containing the query parameter name and an iterable with one or more elements, which will be populated into the query individually
+    '''
+    construct_web_query assumes query_list is an iterable, where each element is a tuple containing the query parameter name and an iterable with one or more elements, which will be populated into the query individually
+    '''
     web_query=''
     if len(query_list) > 0:
         web_query += "?"
         for query_idx in range(len(query_list)):
+            # New query field
+            # Get query name and value list
             query_name,values = query_list[query_idx]
-            for value_idx in range(len(values)):
-                if value_idx == 0:
-                    web_query += query_name + '=' + values[value_idx]
-                else:
-                    web_query += query_separator + query_name + '=' + values[value_idx]
-            if query_idx+1 < len(query_list):
-                web_query+=query_separator    
+            # After the first query, separate the queries
+            if query_idx > 0:
+                web_query += query_separator
+            # Even queries without values get query names
+            web_query += query_name
+            # If the query has a value, use an equals:
+            if len(values) > 0:
+                web_query += "="
+                # Then place each element after the equals, comma separated:
+                for value_idx in range(len(values)):
+                    if value_idx > 0:
+                        web_query += query_separator + query_name + "=" #","
+                    web_query += values[value_idx]    
     return web_scheme+"://"+web_netloc+web_path+web_query+web_fragment
 
-# construct URLs which query USGS server
-# TODO: generalize script, maybe add to separate thmsoc URL handling script?
 def construct_usgs_query(
         station_code, 
         start_datetime: dt.datetime, 
         end_datetime: dt.datetime, 
         sampling_period, 
         elements_list=['X','Y','Z'],
-        usgs_remote_source_path='/ws/algorithms/filter/'
+        usgs_remote_source_path='/ws/algorithms/filter/',
+        data_format = 'json'
         ):
+    '''
+    construct URLs which query USGS server
+    '''
     usgs_netloc='geomag.usgs.gov'
     usgs_path=usgs_remote_source_path
     usgs_query_list=[
         ('elements',elements_list),
-        ('format',['iaga2002']),
+        ('format',[data_format]), # was formerly 'iaga2002'
         ('id',[get_source_alias(station_code).upper()]),
         ('type',['variation']),
-        ('starttime',[start_datetime.strftime('%Y-%m-%dT%H:%M:%S.%fZ')]),
-        ('endtime',[end_datetime.strftime('%Y-%m-%dT%H:%M:%S.%fZ')]),
-        ('output_sampling_period',[sampling_period])
+        ('starttime',[start_datetime.strftime('%Y-%m-%dT%H:%M:%S.%fZ')[:-4]]),
+        ('endtime',[end_datetime.strftime('%Y-%m-%dT%H:%M:%S.%fZ')[:-4]]),
+        ('output_sampling_period',[sampling_period]),
+        ('starttime_only',["True"])
     ]
     return construct_web_query(web_netloc=usgs_netloc,web_path=usgs_path,query_list=usgs_query_list)
 
-# create an sql update query from dict containing fields and associated values
 def sql_insert_update_query(db_table:str, in_dict:dict) -> str:
+    '''
+    create an sql update query from dict containing fields and associated values
+    '''
     query_str = 'INSERT INTO '
     query_str += db_table + '(site,DataDate,'
     query_values_str = '"' + in_dict["site"] + '","' + in_dict["DataDate"] + '",'
@@ -105,10 +102,12 @@ def sql_insert_update_query(db_table:str, in_dict:dict) -> str:
     
     return query_str
 
-# handle USGS alias
-# TODO: update gmag.py in pyspedas to load themis and source aliases
-# currently, takes THEMIS alias and corrects if source alias is different
 def get_source_alias(station_code:str) -> str:
+    '''
+    handle USGS alias
+    '''
+    # TODO: update gmag.py in pyspedas to load themis and source aliases currently, takes THEMIS alias and corrects if source alias is different
+
     if station_code.lower() == "kevo":
         station_name_sourcealias = "kev"
     else:
@@ -117,8 +116,6 @@ def get_source_alias(station_code:str) -> str:
 
 def get_usgs_variometer_avail(station_code:str,data_date:dt.datetime):
     print("Checking "+ station_code.upper() +" availability for date: " + data_date.strftime('%Y-%m-%d') + "...") 
-    #avail_netloc='service.iris.edu' 
-    # Setting network location to earthscope since iris should be getting discontinued:
     avail_netloc='service.earthscope.org' 
     avail_path='/fdsnws/availability/1/extent'
     # add channel at end:
@@ -142,9 +139,6 @@ def get_usgs_variometer_avail(station_code:str,data_date:dt.datetime):
         urllib3.request("GET", url2).status,
         urllib3.request("GET", urlZ).status
         ]
-    #if 404 in response_status_list:
-    #    print(station_code.upper() + " data is NOT available for the date " + data_date.strftime('%Y-%m-%d'))
-    #    return False
     if response_status_list != [200,200,200]:
         print("-> " + station_code.upper() + " data is NOT available for date: " + data_date.strftime('%Y-%m-%d') + ". Skipping..." )
         return False
@@ -163,7 +157,6 @@ def get_usgs_variometer_cal_history(station_code:str) -> str:
             ('format',['xml']),
             ('nodata',['404'])
             ]) # omitting ('channel','BF?'), for now, until earthscope fixes indexing issue
-    
     # Attempt to make url request: 
     try:
         url_response_bytes = urllib3.request(
@@ -184,19 +177,243 @@ def get_usgs_variometer_cal_history(station_code:str) -> str:
             print("ERROR: Invalid status returned: " + str(url_response_bytes.status) + ". Calibration date could not be determined.")
             return ""
     
-    #url_resp = urllib3.request("GET", url)
     root=ET.fromstring(url_resp_str)
-    #root=ET.fromstring(url_response_bytes.data)
     
     change_datetimes = []
-    change_datetimes.append(list_max([change.attrib['changetime'] for change in root.findall(".//*[@code='BF1']..")]))
-    change_datetimes.append(list_max([change.attrib['changetime'] for change in root.findall(".//*[@code='BF2']..")]))
-    change_datetimes.append(list_max([change.attrib['changetime'] for change in root.findall(".//*[@code='BFZ']..")]))
-    change_datetimes.append(list_max([change.attrib['changetime'] for change in root.findall("./*[@class='StationLocation']")]))
+    change_datetimes.append(str_list_max([change.attrib['changetime'] for change in root.findall(".//*[@code='BF1']..")]))
+    change_datetimes.append(str_list_max([change.attrib['changetime'] for change in root.findall(".//*[@code='BF2']..")]))
+    change_datetimes.append(str_list_max([change.attrib['changetime'] for change in root.findall(".//*[@code='BFZ']..")]))
+    change_datetimes.append(str_list_max([change.attrib['changetime'] for change in root.findall("./*[@class='StationLocation']")]))
     
-    cal_date_latest_str = list_max(change_datetimes)
+    cal_date_latest_str = str_list_max(change_datetimes)
     print("-> " + station_code.upper() + " data last calibrated on " + cal_date_latest_str)
     return cal_date_latest_str
+
+def json2iaga2002(str_json_segment:str) -> str:
+    '''
+    A function to take a json of the data and convert it to an iaga2002 formatted string.
+
+    Only a single start time should be provided, so the time series will need to be created from the start time and the sampling period
+    '''
+    NINES = numpy.float64("99999")
+    json_segment = json.loads(str_json_segment)
+    header_dict = {
+        "Format":"IAGA-2002",
+        "Source of Data":"United States Geological Survey (USGS)"
+    }
+    header_label_dict = {
+        "name":"Station Name",
+        "iaga_code":"IAGA CODE",
+        "sensor_orientation":"Sensor Orientation",
+        "data_type":"Data Type",
+        "sampling_period":"Data Interval Type"
+    }
+    t_delta = dt.timedelta(seconds=1)
+    for header_key in ["name","iaga_code","coordinates","sensor_orientation","data_type","sampling_period"]:
+        json_header_dict = json_segment["metadata"]["intermagnet"]
+        if header_key in ["name","iaga_code","coordinates"]:
+            json_header_dict = json_header_dict["imo"]
+        if header_key in json_header_dict:
+            match header_key:
+                case "coordinates":
+                    header_dict["Geodetic Latitude"] = json_header_dict[header_key][1]
+                    header_dict["Geodetic Longitude"] = json_header_dict[header_key][0]
+                    header_dict["Elevation"] = json_header_dict[header_key][2]
+                case "sensor_orientation":
+                    if len(json_header_dict[header_key]) < 4:
+                        header_dict["Reported"] = json_header_dict[header_key] + "NUL"
+                    else:
+                        header_dict["Reported"] = json_header_dict[header_key]
+                    header_dict[header_label_dict[header_key]] = json_header_dict[header_key]
+                case "sampling_period":
+                    match str(json_header_dict[header_key]):
+                        case "1.0":
+                            header_dict[header_label_dict[header_key]] = "1-second"
+                        case "0.1":
+                            t_delta = dt.timedelta(milliseconds=100)
+                case _:
+                    header_dict[header_label_dict[header_key]] = json_header_dict[header_key]
+    
+    # Make header:
+    header_str = ""
+    for key_name in header_dict.keys():
+        header_str += " " + key_name.ljust(23) + str(header_dict[key_name]).ljust(45) + "|" + "\n"
+    if "Data Interval Type" in header_dict:
+        header_str += " # Vector 1-second values are computed from 10 Hz values using a     |" + "\n"
+        header_str += " # Blackman filter (123 taps, cutoff 0.25Hz) centered on the start   |" + "\n"
+        header_str += " # of the second.                                                    |" + "\n"
+        
+    header_str += " # DISCLAIMER                                                        |" + "\n"
+    header_str += " # This is provisional data. Any data secured from the USGS database |" + "\n"
+    header_str += " # that are identified as provisional have not received Director's   |" + "\n"
+    header_str += " # approval and are subject to revision. Source and Authority: U.S.  |" + "\n"
+    header_str += " # Geological Survey Manual, Section 500.24                          |" + "\n"
+    
+    json_data = json_segment["values"]
+    header_str += "DATE".ljust(11) + "TIME".ljust(13) + "DOY".ljust(8)
+    header_str += (header_dict["IAGA CODE"] + json_data[0]["id"]).ljust(10)
+    header_str += (header_dict["IAGA CODE"] + json_data[1]["id"]).ljust(10)
+    header_str += (header_dict["IAGA CODE"] + json_data[2]["id"]).ljust(10)
+    header_str += (header_dict["IAGA CODE"] + "NUL").ljust(7)
+    header_str += "|"
+
+    if len(json_data[0]["values"]) == len(json_data[1]["values"]) == len(json_data[2]["values"]):
+        data_length = len(json_data[0]["values"])
+    else: 
+        raise ValueError("ERROR: Components have differing number of elements!","Component arrays had differing length")
+        
+    # initialize with start time:
+    # format: 2025-11-17T00:00:00.069Z
+    iaga_data_str = ""     
+    row_datetime = dt.datetime.strptime(json_segment["times"][0], '%Y-%m-%dT%H:%M:%S.%fZ')
+    iaga_data_arr = [" "] * data_length
+    for i in range(data_length):
+        iaga_data_row_str = ""
+        # Date:
+        iaga_data_row_str += row_datetime.strftime('%Y-%m-%d').ljust(11)
+        # time:
+        iaga_data_row_str += row_datetime.strftime('%H:%M:%S.%f')[:-3].ljust(13)
+        # DOY
+        iaga_data_row_str += row_datetime.strftime('%j').ljust(8)
+        # component 1:
+        if "NoneType" in [
+            type(json_data[0]["values"][i]).__name__,
+            type(json_data[1]["values"][i]).__name__,
+            type(json_data[2]["values"][i]).__name__]: raise ValueError("ERROR: JSON is missing data!","Segment was missing data.")
+        for j in range(3):
+            iaga_data_row_str += ("%.2f" % json_data[j]["values"][i]).ljust(10)
+        # component nul:
+        iaga_data_row_str += ("%.2f" % NINES).ljust(7)
+        
+        # Assign value in array to line:
+        iaga_data_arr[i] = iaga_data_row_str
+        # increment time by sampling rate:
+        row_datetime = row_datetime + t_delta
+    iaga_data_str = "\n".join(iaga_data_arr)
+    
+    iaga_arr = [header_str,iaga_data_str]
+    iaga_str = "\n".join(iaga_arr) + "\n"
+    
+    return iaga_str
+
+def decode2string(bytes_response):
+    '''
+    take in a urllib3 response object as bytes and decode to utf-8 function is separate from others so concurrent module can run decode calls in parallel
+    '''
+    try:
+        bytes_response_read = bytes_response.read()
+        # we should be able to safely close the original url responses:
+        bytes_response.close()
+        string_response=bytes_response_read.decode('utf-8')
+        if string_response == '': 
+            raise ValueError(
+                "ERROR! Decoded bytes_response is empty!",
+                "Empty response")
+        else:
+            return string_response
+    except urllib3.exceptions.IncompleteRead:
+        raise ValueError(
+            "ERROR! Incomplete file due to timed out connection!",
+            "Connection timed out during retrieval")
+    except urllib3.exceptions.ProtocolError:
+        raise ValueError(
+            "ERROR! Incomplete file due to timed out connection!",
+            "Connection timed out during retrieval")    
+
+def decode_and_convert(bytes_response) -> str:
+    str_response = decode2string(bytes_response)
+    output_string = json2iaga2002(str_response)
+    return output_string
+
+def correct_start_time(
+        station_code:str,
+        start_datetime:dt.datetime,
+        sampling_period:str,
+        recursive_run:bool=False) -> dt.datetime:
+    '''
+    Makes a quick USGS iaga2002 query for a very short timespan, and checks status
+    if the status returned is 500, slightly adjust start time and try again 
+    '''
+    url=construct_usgs_query(
+        station_code=station_code,
+        start_datetime=start_datetime,
+        end_datetime=start_datetime + dt.timedelta(seconds=1),
+        data_format = 'iaga2002',
+        sampling_period=sampling_period)
+    http_1 = urllib3.PoolManager(num_pools=24) # num_pools=10
+    retries_settings=urllib3.Retry(
+        connect=0,
+        read=2,
+        backoff_factor=0.5)
+    url_response_bytes = http_1.request(
+        "GET", 
+        url, 
+        retries=retries_settings,
+        decode_content=False,
+        preload_content=False,
+        redirect=False,
+        timeout=30)
+    url_response_status = url_response_bytes.status
+    url_response_bytes.close()
+    match url_response_status:
+        case 200:
+            return start_datetime
+        case 500:
+            if recursive_run: 
+                raise ValueError(
+                    "ERROR! Remote source encountered internal server error.",
+                    "Remote source internal server error")
+            else:
+                print("WARNING: Possible component array mismatch detected; modifying query to attempt correction.")
+                modified_start_time = correct_start_time(
+                    station_code=station_code,
+                    start_datetime=start_datetime - dt.timedelta(milliseconds=1),
+                    sampling_period=sampling_period,
+                    recursive_run=True)
+                return modified_start_time
+        case _:
+            raise ValueError(
+                "ERROR: Invalid status returned: " + str(url_response_bytes.status) + ".",
+                "Bad response status code: " + str(url_response_bytes.status)) 
+
+def retrieve_file_bytes(
+        station_code:str,
+        start_datetime:dt.datetime,
+        end_datetime:dt.datetime,
+        sampling_period:str,
+        max_num_retries:int):
+    # use parameters to construct query, make request:
+    if sampling_period == "0.1":
+        start_datetime = correct_start_time(
+            station_code=station_code,
+            start_datetime=start_datetime,
+            sampling_period=sampling_period)
+    url=construct_usgs_query(
+        station_code=station_code,
+        start_datetime=start_datetime,
+        end_datetime=end_datetime,
+        sampling_period=sampling_period)
+    # Attempt to make url request: 
+    http = urllib3.PoolManager(num_pools=24) # num_pools=10
+    retries_settings=urllib3.Retry(
+        connect=0,
+        read=max_num_retries,
+        backoff_factor=0.5)
+    url_response_bytes = http.request(
+        "GET", 
+        url, 
+        retries=retries_settings,
+        decode_content=False,
+        preload_content=False,
+        redirect=False,
+        timeout=30)
+    match url_response_bytes.status:
+        case 200:
+            return url_response_bytes
+        case _:
+            raise ValueError(
+                "ERROR: Invalid status returned: " + str(url_response_bytes.status) + ".",
+                "Bad response status code: " + str(url_response_bytes.status)) 
 
 def retrieve_a_file(
         station_code:str,
@@ -206,135 +423,95 @@ def retrieve_a_file(
         sampling_rate:str='1',
         max_num_retries:int=0) -> dict:
     out_dict = {"LastAttemptedAccessTime":"","LastSuccessfulAccessTime":"","error_status":""}
-    # use sampling_rate arg to define additional retrieval parameters
-    match sampling_rate:
-        case '1':
-            sampling_period_val='1'
-            workdir_subdir = Path(f"{variometer_workdir}/{sampling_rate}_hz")
-            Path(workdir_subdir).mkdir(parents=True, exist_ok=True)
-            output_filepath_list = [Path(f"{workdir_subdir}/{station_code.lower()}{data_date.strftime('%Y%m%d')}vsec.sec")]
-            if mirror_dir is not None:
-                mirror_subdir = Path(f"{mirror_dir}/{station_code.lower()}/1_hz/{data_date.strftime('%Y')}/{data_date.strftime('%m')}")
-                mirror_subdir.mkdir(parents=True, exist_ok=True)
-                output_filepath_list.append(Path(f"{mirror_subdir}/{station_code.lower()}{data_date.strftime('%Y%m%d')}vsec.sec"))
-            duration=24 # duration of each segment, in hours
-            segment_end_str = "000"
-        case '10':
-            sampling_period_val='0.1'
-            workdir_subdir = Path(f"{variometer_workdir}/{sampling_rate}_hz")
-            Path(workdir_subdir).mkdir(parents=True, exist_ok=True)
-            output_filepath_list = [Path(f"{workdir_subdir}/{station_code.lower()}{data_date.strftime('%Y%m%d')}vdec.dec")]
-            duration=4 # duration of each segment, in hours
-            segment_end_str = "999"
-        case _:
-            print("ERROR: Sampling rate not recognized")
-            out_dict["error_status"] = "Invalid Sampling Rate"
-            return out_dict
-    
-    print("Retrieving " + station_code.upper() + " data for "+ data_date.strftime('%Y-%m-%d') +" in " + str(round(24/duration)) + " segments... ")
-    start_time_1file = dt.datetime.now()
-    out_dict["LastAttemptedAccessTime"] = dt.datetime.strftime(start_time_1file,'%Y-%m-%d %H:%M:%S')
-    # make requests to USGS server and collect response objects in a list: 
-    url_response_bytes_list = []
-    # start hour increases by length of duration
-    for start_hour in range(0, 24, duration):
-        segment_start_time_1file = dt.datetime.now()
-        # end time will be 0.001 second before next segment start time:
-        end_hour = start_hour + duration - 1
-        data_date_str = data_date.strftime('%Y-%m-%d')
-        start_datetime_val=dt.datetime.strptime(data_date_str + "T" + str(start_hour) + ":00:00.000Z", '%Y-%m-%dT%H:%M:%S.%fZ')
-        end_datetime_val=dt.datetime.strptime(data_date_str + "T" + str(end_hour) + ":59:59."+segment_end_str+"Z", '%Y-%m-%dT%H:%M:%S.%fZ')
+    try:
+        # use sampling_rate arg to define additional retrieval parameters
+        match sampling_rate:
+            case '1':
+                sampling_period_val='1'
+                workdir_subdir = Path(f"{variometer_workdir}/{sampling_rate}_hz")
+                Path(workdir_subdir).mkdir(parents=True, exist_ok=True)
+                output_filepath_list = [Path(f"{workdir_subdir}/{station_code.lower()}{data_date.strftime('%Y%m%d')}vsec.sec")]
+                if mirror_dir is not None:
+                    mirror_subdir = Path(f"{mirror_dir}/{station_code.lower()}/1_hz/{data_date.strftime('%Y')}/{data_date.strftime('%m')}")
+                    mirror_subdir.mkdir(parents=True, exist_ok=True)
+                    output_filepath_list.append(Path(f"{mirror_subdir}/{station_code.lower()}{data_date.strftime('%Y%m%d')}vsec.sec"))
+                duration=12 # duration of each segment, in hours # formerly 24
+                segment_end_str = "000"
+            case '10':
+                sampling_period_val='0.1'
+                workdir_subdir = Path(f"{variometer_workdir}/{sampling_rate}_hz")
+                Path(workdir_subdir).mkdir(parents=True, exist_ok=True)
+                output_filepath_list = [Path(f"{workdir_subdir}/{station_code.lower()}{data_date.strftime('%Y%m%d')}vdec.dec")]
+                duration=3 # duration of each segment, in hours # formerly 4
+                segment_end_str = "999"
+            case _:
+                raise ValueError("ERROR: Sampling rate not recognized","Invalid Sampling Rate")
+        print("Retrieving " + station_code.upper() + " data for "+ data_date.strftime('%Y-%m-%d') +" in " + str(round(24/duration)) + " segments... ")
+        start_time_1file = dt.datetime.now()
+        out_dict["LastAttemptedAccessTime"] = dt.datetime.strftime(start_time_1file,'%Y-%m-%d %H:%M:%S')
 
-        # use parameters to construct query, make request:
-        url=construct_usgs_query(station_code=station_code,start_datetime=start_datetime_val,end_datetime=end_datetime_val,sampling_period=sampling_period_val)
-        
-        # Attempt to make url request: 
-        http = urllib3.PoolManager(num_pools=10)
-        retries_settings=urllib3.Retry(
-            connect=0,
-            read=max_num_retries,
-            backoff_factor=0.5)
-        try:
-            url_response_bytes = http.request(
-                "GET", 
-                url, 
-                retries=retries_settings,
-                decode_content=False,
-                preload_content=False,
-                redirect=False,
-                timeout=30)
-            #url_response_bytes = http.request("GET",url,decode_content=False,preload_content=False)
-
-        except urllib3.exceptions.TimeoutError:
-            print("ERROR: Connection timed out! Aborting file retrieval... ---")
-            out_dict["error_status"] = "Connection timed out"
-            return out_dict
-        except urllib3.exceptions.MaxRetryError:
-            print("ERROR: Connection could not be established after " + str(max_num_retries + 1) + " attempt(s); Aborting file retrieval... ---")
-            out_dict["error_status"] = "Max connection retry limit reached"
-            return out_dict
-        else:
-            # If we get a bad response, exit with an error status
-            if url_response_bytes.status == 200:
-                # If we received a good response, append to list of responses
-                print("-> Segment "+ str(round((start_hour+duration)/duration)) + "/"+str(round(24/duration))+" retrieval complete. Elapsed %.0f seconds." % (dt.datetime.now() - segment_start_time_1file).seconds)
-                url_response_bytes_list.append(url_response_bytes)
-            else:
-                print("ERROR! Invalid status returned: " + str(url_response_bytes.status) + " after %.0f seconds; Aborting file retrieval... ---" % (dt.datetime.now() - segment_start_time_1file).seconds)
-                out_dict["error_status"] = "Connection returned status: " + str(url_response_bytes.status)
-                return out_dict
-    
-    # Take list of byte responses and decode:
-    decoding_start_time = dt.datetime.now()
-    print("Download of all segments complete. Elapsed %.0f seconds." % (decoding_start_time - start_time_1file).seconds)
-    url_response_string_list=[]
-    # using the ThreadPoolExecutor object, map input url_response_bytes_list to output url_response_string_list, running on 24/duration threads (should be 6 for 10 Hz, 1 for 1 Hz)
-    with futures.ThreadPoolExecutor(round(24/duration)) as executor:
-        url_response_string_list = executor.map(decode2string, url_response_bytes_list)
-    url_response_string_list=list(url_response_string_list)
-    
-    # verify that the output strings aren't empty or contain timeout signatures. if they do, exit with error status
-    verification_start_time=dt.datetime.now()
-    print("Decoding complete. Elapsed %.0f seconds." % (verification_start_time - decoding_start_time).seconds)
-    # loop once, check for timeout strings:
-    for url_response_string in url_response_string_list:
-        # check for timeout contents, abandon process if detected.
-        if url_response_string == '':
-            print("ERROR! Incomplete file due to empty segment! File could not be written; Aborting file retrieval... ")
-            out_dict["error_status"] = "At least one of the segments was empty"
-            return out_dict
-        elif "HTTP/1.1 408 Request Timeout" in url_response_string:
-            print("ERROR! Incomplete file due to timed out connection! File could not be written; Aborting file retrieval... ")
-            out_dict["error_status"] = "Connection timed out during retrieval"
-            return out_dict
-
-    # File strings should be complete and correct. Write strings to file:    
-    writing_start_time = dt.datetime.now()
-    print("File verification complete. Elapsed %.0f seconds." % (writing_start_time - verification_start_time).seconds)
-    out_dict["LastSuccessfulAccessTime"] = dt.datetime.strftime(start_time_1file,'%Y-%m-%d %H:%M:%S')
-    
-    # If output file path already exists, delete it and create a new one:
-    for output_filepath in output_filepath_list:    
-        try:
+        # make requests to USGS server and collect response objects in a list: 
+        url_response_bytes_list = []
+        # start hour increases by length of duration
+        for start_hour in range(0, 24, duration):
+            segment_start_time_1file = dt.datetime.now()
+            # end time will be 0.001 second before next segment start time:
+            end_hour = start_hour + duration - 1
+            data_date_str = data_date.strftime('%Y-%m-%d')
+            start_datetime_val=dt.datetime.strptime(data_date_str + "T" + str(start_hour) + ":00:00.000Z", '%Y-%m-%dT%H:%M:%S.%fZ')
+            end_datetime_val=dt.datetime.strptime(data_date_str + "T" + str(end_hour) + ":59:59."+segment_end_str+"Z", '%Y-%m-%dT%H:%M:%S.%fZ')
+            url_response_bytes = retrieve_file_bytes(
+                station_code=station_code,
+                start_datetime=start_datetime_val,
+                end_datetime=end_datetime_val,
+                sampling_period=sampling_period_val,
+                max_num_retries=max_num_retries)
+            print("-> Segment "+ str(round((start_hour+duration)/duration)) + "/"+str(round(24/duration))+" retrieval complete. Elapsed %.0f seconds." % (dt.datetime.now() - segment_start_time_1file).seconds)
+            url_response_bytes_list.append(url_response_bytes)
+        # Take list of byte responses and decode:
+        decoding_start_time = dt.datetime.now()
+        print("Download of all segments complete. Elapsed %.0f seconds." % (decoding_start_time - start_time_1file).seconds)
+        output_string_list = []
+        with futures.ThreadPoolExecutor(round(24/duration)) as executor:
+            output_string_list = executor.map(decode_and_convert, url_response_bytes_list)
+        output_string_list=list(output_string_list)
+        # File strings should be complete and correct. Write strings to file:    
+        writing_start_time = dt.datetime.now()
+        print("Decoding and conversion complete. Elapsed %.0f seconds." % (writing_start_time - decoding_start_time).seconds)
+        out_dict["LastSuccessfulAccessTime"] = dt.datetime.strftime(start_time_1file,'%Y-%m-%d %H:%M:%S')
+        # If output file path already exists, delete it and create a new one:
+        for output_filepath in output_filepath_list:    
             output_filepath.unlink(missing_ok=True)
             output_file = open(output_filepath, "x")
             output_file.close()
             # For each url response string, append to new file. Only keep the header for the first string:
-            for url_response_string_list_idx in range(len(url_response_string_list)):
-                url_response_string = url_response_string_list[url_response_string_list_idx]    
+            for output_string_list_list_idx in range(len(output_string_list)):
+                output_string = output_string_list[output_string_list_list_idx]
                 # if the url response string comes first in the list, keep the header; otherwise, remove lines containing the | character followed by a newline:
-                if url_response_string_list_idx == 0:
-                    string_towrite = url_response_string
+                if output_string_list_list_idx == 0:
+                    string_towrite = output_string
                 else:
-                    string_towrite = re.sub(r".*\|\n", "", url_response_string)
+                    string_towrite = re.sub(r".*\|\n", "", output_string)
                 with open(output_filepath, "a") as of:
-                    of.write(string_towrite)
-            end_time_1file = dt.datetime.now()
-            print("File writing complete. Elapsed %.0f seconds." % (end_time_1file - writing_start_time).seconds)
-            print("Total file retrieval complete. Elapsed time: %.0f seconds." % (end_time_1file - start_time_1file).seconds)            
-        except:
-            print("ERROR! The output file could not be written: " + str(output_filepath))
-            out_dict["error_status"] = "Failed to write data to output file."
+                    of.write(string_towrite)   
+        end_time_1file = dt.datetime.now()
+        print("File writing complete. Elapsed %.0f seconds." % (end_time_1file - writing_start_time).seconds)
+        print("Total file retrieval complete. Elapsed time: %.0f seconds." % (end_time_1file - start_time_1file).seconds)
+    except urllib3.exceptions.TimeoutError:
+        raise ValueError(
+            "ERROR: Connection timed out!",
+            "Connection timed out during retrieval")
+    except urllib3.exceptions.MaxRetryError:
+        raise ValueError(
+            "ERROR: Connection could not be established after " + str(max_num_retries + 1) + " attempt(s)",
+            "Max connection retry limit reached")
+    
+    except ValueError as error:
+        print(error.args[0] + " File could not be written; Aborting file retrieval...")
+        out_dict["error_status"] = error.args[1]
+    except:
+        print("ERROR! The output file could not be written.")
+        out_dict["error_status"] = "Failed to write data to output file."
     return out_dict
 
 def run_gmag_retrieve_usgs_variometer(
@@ -424,7 +601,7 @@ def run_gmag_retrieve_usgs_variometer(
                 print(sql_insert_update_query(db_table=db_table, in_dict=result_dict), file=of)
                 #of.write(sql_insert_update_query(db_table=db_table, in_dict=result_dict))
             if result_dict["error_status"] != "":
-                missing_file_list += "Station: " + station_code.upper() + ", Date: "+ current_date.strftime('%Y-%m-%d') +", Issue: " + result_dict["error_status"] + "\n"
+                missing_file_list += "Station: " + (station_code.upper() + ",").ljust(5) + " Date: "+ current_date.strftime('%Y-%m-%d') +", Issue: " + result_dict["error_status"] + "\n"
     print("------ Script complete. Elapsed %.0f seconds ------" % (dt.datetime.now() - main_start_time).seconds)
     if missing_file_list != "":
         print("Retrieval was attempted for the following files, but failed for the following reasons: ")
@@ -448,4 +625,3 @@ def run_gmag_retrieve_usgs_variometer(
 
 if __name__ == "__main__":
     run_gmag_retrieve_usgs_variometer(start_date="2025-11-17",end_date="2025-11-17", station_list=['s61a'],sampling_rate='10')
-    


### PR DESCRIPTION
Fixes bug in the CLI script for the station code arguments, and now ignores case. Overhauled the error handling to make debugging easier. Primarily, this implements resource efficient recommendations from USGS to reduce possible impact of retrieval on USGS server processing and bandwidth, and can improve retrieval times (particularly in peak hours) on our end. Now retrieves data in JSON format with crucially only the starting time included. This means that the time array no longer needs to be sent to us from USGS servers, and instead can instead be constructed using the starting time and the sampling rate (which can't be accomplished from getting the iaga2002 format directly). With the data in the JSON format, the IAGA2002 format is constructed and written to a file as it originally was, and should be fully compatible with the processing script.

The script now also makes more numerous smaller-sized requests, which USGS has suggested should receive faster responses and be less resource taxing on their end (since their servers take longer to generate requests with more values). This does not affect the decoding and data extraction time, since this is done in parallel. The retrieval time (at least at times when the USGS server is getting a lot of traffic) is fairly similar in total to the previous retrieval segment sizes. 

This script now implements a workaround for mismatched time stamps, which USGS is currently in the process of addressing. For the 10 Hz data, the original Earthscope timestamps sometimes differ between the three field components, which are recorded and archived separately. It seems to only differ by a single element in the length of the data array. In this case, we fill the last element with the "99999.00" iaga missing value, which should be interpreted as null by the processing script. This issue does not affect the 1 Hz data because the data is down-sampled from the raw 10 Hz sampling rate.

Closes #4